### PR TITLE
chore: bump whatwg-url to latest

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
-        run: npm install
+        run: |
+          npm config set node_gyp "$PWD/node_modules/node-gyp/bin/node-gyp.js"
+          npm config get node_gyp
+          npm install
       - name: Test
         run: npm test

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
-    "@types/whatwg-url": "^8.2.0",
+    "@types/whatwg-url": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "eslint": "^7.9.0",
@@ -56,10 +56,10 @@
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "os-dns-native": "^1.0.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "whatwg-url": "^8.5.0"
+    "whatwg-url": "^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "gen-esm-wrapper": "^1.1.0",
     "mocha": "^8.1.3",
+    "node-gyp": "^9.1.0",
     "nyc": "^15.1.0",
     "os-dns-native": "^1.0.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
For the same reason as in https://github.com/mongodb-js/mongodb-connection-string-url/pull/9