### PR TITLE
fix: normalize domains to ensure FQDN equality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ const ALLOWED_TXT_OPTIONS: Readonly<string[]> = ['authSource', 'replicaSet', 'lo
 
 function matchesParentDomain (srvAddress: string, parentDomain: string): boolean {
   const regex = /^.*?\./;
-  const srv = `.${(srvAddress.endsWith(".") ? srvAddress.slice(0, -1) : srvAddress).replace(regex, "")}`;
-  const parent = `.${(parentDomain.endsWith(".") ? parentDomain.slice(0, -1) : parentDomain).replace(regex, "")}`;
+  const srv = `.${(srvAddress.endsWith('.') ? srvAddress.slice(0, -1) : srvAddress).replace(regex, '')}`;
+  const parent = `.${(parentDomain.endsWith('.') ? parentDomain.slice(0, -1) : parentDomain).replace(regex, '')}`;
   return srv.endsWith(parent);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ const ALLOWED_TXT_OPTIONS: Readonly<string[]> = ['authSource', 'replicaSet', 'lo
 
 function matchesParentDomain (srvAddress: string, parentDomain: string): boolean {
   const regex = /^.*?\./;
-  const srv = `.${srvAddress.replace(regex, '')}`;
-  const parent = `.${parentDomain.replace(regex, '')}`;
+  const srv = `.${(srvAddress.endsWith(".") ? srvAddress.slice(0, -1) : srvAddress).replace(regex, "")}`;
+  const parent = `.${(parentDomain.endsWith(".") ? parentDomain.slice(0, -1) : parentDomain).replace(regex, "")}`;
   return srv.endsWith(parent);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,24 @@ type Options = {
 
 const ALLOWED_TXT_OPTIONS: Readonly<string[]> = ['authSource', 'replicaSet', 'loadBalanced'];
 
-function matchesParentDomain (srvAddress: string, parentDomain: string): boolean {
-  const regex = /^.*?\./;
-  const srv = `.${(srvAddress.endsWith('.') ? srvAddress.slice(0, -1) : srvAddress).replace(regex, '')}`;
-  const parent = `.${(parentDomain.endsWith('.') ? parentDomain.slice(0, -1) : parentDomain).replace(regex, '')}`;
-  return srv.endsWith(parent);
+function matchesParentDomain (address: string, parentDomain: string): void {
+  const normalize = (s: string): string => (s.endsWith('.') ? s.slice(0, -1) : s);
+  const addr = normalize(address);
+  const parent = normalize(parentDomain);
+
+  const addrParts = addr.split('.');
+  const parentParts = parent.split('.');
+  const isParentShort = parentParts.length < 3;
+  if (isParentShort && addrParts.length <= parentParts.length) {
+    throw new MongoParseError('Server record does not have at least one more domain level than parent URI');
+  }
+
+  // Prevent insecure "TLD-only matching" on short domains
+  const requiredSuffix = `.${parentParts.slice(isParentShort ? 0 : 1).join('.')}`;
+  const addrSuffix = `.${addrParts.slice(1).join('.')}`;
+  if (!addrSuffix.endsWith(requiredSuffix)) {
+    throw new MongoParseError('Server record does not share hostname with parent URI');
+  }
 }
 
 async function resolveDnsSrvRecord (dns: NonNullable<Options['dns']>, lookupAddress: string, srvServiceName: string): Promise<string[]> {
@@ -27,9 +40,7 @@ async function resolveDnsSrvRecord (dns: NonNullable<Options['dns']>, lookupAddr
   }
 
   for (const { name } of addresses) {
-    if (!matchesParentDomain(name, lookupAddress)) {
-      throw new MongoParseError('Server record does not share hostname with parent URI');
-    }
+    matchesParentDomain(name, lookupAddress);
   }
 
   return addresses.map(r => r.name + ((r.port ?? 27017) === 27017 ? '' : `:${r.port}`));

--- a/test/index.ts
+++ b/test/index.ts
@@ -49,26 +49,26 @@ describe('resolveMongodbSrv', () => {
     });
 
     it('rejects non-mongodb schemes', async () => {
-      assert.rejects(resolveMongodbSrv('http://somewhere.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('http://somewhere.example.com', { dns }));
     });
 
     it('rejects mongodb+srv with port', async () => {
-      assert.rejects(resolveMongodbSrv('mongodb+srv://somewhere.example.com:27017', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://somewhere.example.com:27017', { dns }));
     });
 
     it('rejects when the SRV lookup rejects', async () => {
       srvError = new Error();
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('rejects when the SRV lookup returns no results', async () => {
       srvResult = [];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('rejects when the SRV lookup returns foreign hostnames', async () => {
       srvResult = [{ name: 'server.example.org', port: 27017 }];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('respects SRV-provided ports', async () => {
@@ -81,7 +81,7 @@ describe('resolveMongodbSrv', () => {
     it('rejects when the TXT lookup rejects with a fatal error', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtError = Object.assign(new Error(), { code: 'ENOENT' });
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('does not reject when the TXT lookup results in ENOTFOUND', async () => {
@@ -103,13 +103,13 @@ describe('resolveMongodbSrv', () => {
     it('rejects when the TXT lookup returns more than one result', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['a'], ['b']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('rejects when the TXT lookup returns invalid connection string options', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['a=b']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('accepts TXT lookup authSource', async () => {
@@ -123,7 +123,7 @@ describe('resolveMongodbSrv', () => {
     it('rejects empty TXT lookup authSource', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['authSource=']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('prioritizes URL-provided over TXT lookup authSource', async () => {
@@ -145,7 +145,7 @@ describe('resolveMongodbSrv', () => {
     it('rejects empty TXT lookup replicaSet', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['replicaSet=']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('prioritizes URL-provided over TXT lookup replicaSet', async () => {
@@ -174,13 +174,13 @@ describe('resolveMongodbSrv', () => {
     it('rejects empty TXT lookup loadBalanced', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['loadBalanced=']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('rejects non true/false TXT lookup loadBalanced', async () => {
       srvResult = [{ name: 'asdf.example.com', port: 27017 }];
       txtResult = [['loadBalanced=bla']];
-      assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://server.example.com', { dns }));
     });
 
     it('prioritizes URL-provided over TXT lookup loadBalanced', async () => {
@@ -229,6 +229,12 @@ describe('resolveMongodbSrv', () => {
     it('rejects SRV records without additional subdomain when parent domain has fewer than 3 parts', async () => {
       txtResult = [];
       srvResult = [{ name: 'example.com', port: 27017 }];
+      await assert.rejects(resolveMongodbSrv('mongodb+srv://example.com', { dns }));
+    });
+
+    it('not strip first subdomain when parent domain has fewer than 3 part to prevent TLD-only matching', async () => {
+      txtResult = [];
+      srvResult = [{ name: 'asdf.malicious.com', port: 27017 }];
       await assert.rejects(resolveMongodbSrv('mongodb+srv://example.com', { dns }));
     });
 


### PR DESCRIPTION
`mongosh` uses `@mongodb-js/devtools-connect`, and `@mongodb-js/devtools-connect` uses `resolve-mongodb-srv`. In the current implementation, if you explicitly indicate the FQDN by adding ".", it will be recognized as a different domain. So we need to fix this.